### PR TITLE
[Feat]: Migration to vite from webpack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for React client
 
 # Build react client
-FROM node:17-alpine
+FROM node:18-alpine
 
 # Working directory be app
 WORKDIR /usr/src/app

--- a/index.html
+++ b/index.html
@@ -2,13 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="IITP Test Portal" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="apple-touch-icon" href="/logo192.png" />
 
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="/manifest.json" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -33,5 +33,6 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "react-quill": "^2.0.0-beta.4",
     "react-router": "^6.2.1",
     "react-router-dom": "^6.2.1",
-    "react-scripts": "5.0.0",
     "react-to-print": "^2.14.4",
     "redocx": "^1.1.4",
     "sass": "^1.48.0",
@@ -54,10 +53,9 @@
     "web-vitals": "^2.1.2"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "start": "vite --host",
+    "build": "tsc && vite build",
+    "serve": "vite preview"
   },
   "eslintConfig": {
     "extends": [
@@ -83,6 +81,11 @@
     "@types/react-csv": "^1.1.2",
     "@types/react-date-range": "^1.4.4",
     "@types/react-highlight-words": "^0.16.4",
-    "mini-css-extract-plugin": "2.4.4"
+    "@vitejs/plugin-react": "^2.2.0",
+    "@vitejs/plugin-react-refresh": "^1.3.6",
+    "mini-css-extract-plugin": "2.4.4",
+    "vite": "^3.2.3",
+    "vite-plugin-env-compatible": "^1.1.1",
+    "vite-plugin-svgr": "^2.2.2"
   }
 }

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -89,7 +89,7 @@ const ListItem: React.FC<UpcomingTestItemProps> = ({
   function handleClickTest() {
     let a = document.createElement("a");
     let token = localStorage.getItem(AUTH_TOKEN);
-    const testLink = process.env.REACT_APP_TEST_PORTAL_URI;
+    const testLink = import.meta.env.VITE_TEST_PORTAL_URI;
     a.href = `${testLink}/auth/${token}/${id}`;
     a.target = "_blank";
     a.click();

--- a/src/pages/Users/Students/Students.tsx
+++ b/src/pages/Users/Students/Students.tsx
@@ -316,7 +316,7 @@ const Students: React.FC<{
   // useEffect(() => {
   //   async function fetchStudents() {
   //     const res = await axios.get(
-  //       `${process.env.REACT_APP_USERS_API}/student/`
+  //       `${import.meta.env.VITE_USERS_API}/student/`
   //     );
   //     console.log({ res });
   //     setData(res.data?.map((item: any) => ({ ...item, key: item.id })));

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -3,7 +3,7 @@ import { AUTH_TOKEN } from "./constants";
 
 export const API_QUESTIONS = () =>
   axios.create({
-    baseURL: `${process.env.REACT_APP_QUESTIONS_API}`,
+    baseURL: `${import.meta.env.VITE_QUESTIONS_API}`,
     headers: {
       authorization: `Bearer ${localStorage.getItem(AUTH_TOKEN)}`,
     },
@@ -11,7 +11,7 @@ export const API_QUESTIONS = () =>
 
 export const API_USERS = () =>
   axios.create({
-    baseURL: `${process.env.REACT_APP_USERS_API}`,
+    baseURL: `${import.meta.env.VITE_USERS_API}`,
     headers: {
       authorization: `Bearer ${localStorage.getItem(AUTH_TOKEN)}`,
     },
@@ -19,7 +19,7 @@ export const API_USERS = () =>
 
 export const API_TESTS = () =>
   axios.create({
-    baseURL: `${process.env.REACT_APP_TESTS_API}`,
+    baseURL: `${import.meta.env.VITE_TESTS_API}`,
     headers: {
       authorization: `Bearer ${localStorage.getItem(AUTH_TOKEN)}`,
     },

--- a/src/utils/constants.tsx
+++ b/src/utils/constants.tsx
@@ -7,15 +7,15 @@ import RenderWithLatex from "../components/RenderWithLatex/RenderWithLatex";
 export const APIS = {
   USERS_API:
     "https://iitpulse.in" ||
-    process.env.REACT_APP_USERS_API ||
+    import.meta.env.VITE_USERS_API ||
     "http://localhost:8080",
   QUESTIONS_API:
     "https://questions.iitpulse.in" ||
-    process.env.REACT_APP_QUESTIONS_API ||
+    import.meta.env.VITE_QUESTIONS_API ||
     "http://localhost:8081",
   TESTS_API:
     "https://tests.iitpulse.in" ||
-    process.env.REACT_APP_TESTS_API ||
+    import.meta.env.VITE_TESTS_API ||
     "http://localhost:8082",
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "ESNext",
     "lib": ["dom", "dom.iterable", "esnext"],
+    "types": ["vite/client", "vite-plugin-svgr/client"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -16,5 +17,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src", "vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "vite";
+import reactRefresh from "@vitejs/plugin-react";
+import svgrPlugin from "vite-plugin-svgr";
+
+// to be used if cannot work without process.env
+// import envCompatible from "vite-plugin-env-compatible";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  build: {
+    outDir: "build",
+  },
+  server: {
+    host: "0.0.0.0",
+    port: 3000,
+  },
+  plugins: [
+    reactRefresh(),
+    svgrPlugin({
+      svgrOptions: {
+        icon: "1.5rem",
+        // default width and height
+
+        // ...svgr options (https://react-svgr.com/docs/options/)
+      },
+    }),
+  ],
+});


### PR DESCRIPTION
Changes
- Replaced webpack with Vite bundler
- Changed the name of all envs from `REACT_APP_VARIABLE` to `VITE_VARIABLE`
- Used `import.meta.env` instead of `process.env` everywhere

Improvements
- Load time improved by 10 times
- Whole server starts in less than 2s
- No need to turn Off the server when `env` changed, Vite takes care of it
-  Bundle size decreased drastically
- Native Support for dynamic imports
- Support for plugins, like `jpg` to `webp` and all other fallback when building
- and more...

What do you need to change?
- You need to replace your env variable names
  - Replace `REACT_APP_` witih `VITE_`

The rest has been automatically taken care of

---
 **NOTE**
If using docker, use the command `docker-compose down` to remove old instances and then do `docker-compose up` again. 
---

Hopefully, you'll notice a significant improvement. If in case the server does not work, try npm install in the client directory first, then repeat. 