### PR TITLE
[Fix]: Image size preserved on pasting and resizing in quill

### DIFF
--- a/src/pages/Questions/Common.tsx
+++ b/src/pages/Questions/Common.tsx
@@ -60,5 +60,6 @@ export const formats = [
   "indent",
   "link",
   "image",
+  "width",
   "formula", // NOT WORKING YET
 ];


### PR DESCRIPTION
Fixes #104 