### PR TITLE
[Feat]: Extract options and separate question

### DIFF
--- a/src/pages/Questions/Objective/Objective.tsx
+++ b/src/pages/Questions/Objective/Objective.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from "react";
-import { Button, Modal, Sidebar } from "../../../components";
+import React, { useEffect, useRef, useState } from "react";
+import { Button, InputField, Modal, Sidebar } from "../../../components";
 import styles from "./Objective.module.scss";
 import ReactQuill, { Quill } from "react-quill";
 import Tabs, { tabsClasses } from "@mui/material/Tabs";
@@ -16,9 +16,9 @@ import {
 import { formats, modules, TabPanel } from "../Common";
 // @ts-ignore
 import ImageResize from "quill-image-resize-module-react";
-import { generateOptions, getOptionID } from "../utils";
+import { extractOptions, generateOptions, getOptionID } from "../utils";
 
-import { Visibility } from "@mui/icons-material";
+import { AutoFixHigh, Visibility } from "@mui/icons-material";
 import { PreviewHTMLModal } from "../components";
 import { PreviewFullQuestion } from "../Questions";
 
@@ -54,6 +54,8 @@ const Objective: React.FC<Props> = ({
   const [previewHTML, setPreviewHTML] = useState("");
   const [previewModalOpen, setPreviewModalOpen] = useState(false);
   const [fullPreviewModalOpen, setFullPreviewModalOpen] = useState(false);
+  const [parseInputOpen, setParseInputOpen] = useState(false);
+  const [rawInputToBeParsed, setRawInputToBeParsed] = useState("");
 
   const [values, setValues] = useState(() => {
     let tempOptions = generateOptions(answerType, 4);
@@ -268,6 +270,33 @@ const Objective: React.FC<Props> = ({
     }
   }, [data, isInitialValuePassed]);
 
+  function handleParseOptions(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    let parsed = extractOptions(rawInputToBeParsed);
+    let vals = [parsed.a, parsed.b, parsed.c, parsed.d];
+    setValues((prev) => ({
+      ...prev,
+      en: {
+        ...prev.en,
+        question: parsed.precedingText,
+        options: prev.en.options.map((option: any, i: number) => ({
+          ...option,
+          value: vals[i],
+          isCorrectAnswer: false,
+        })),
+      },
+      hi: {
+        ...prev.hi,
+        options: prev.hi.options.map((option: any, i: number) => ({
+          ...option,
+          value: vals[i],
+          isCorrectAnswer: false,
+        })),
+      },
+    }));
+    setOptionsCount(vals.length);
+  }
+
   return (
     <section className={styles.container}>
       <div className={styles.header}>
@@ -284,6 +313,11 @@ const Objective: React.FC<Props> = ({
           <label htmlFor="assertionEnglish"></label> */}
         </div>
         <div className={styles.flexRow}>
+          <Tooltip title="Parse Options">
+            <IconButton onClick={() => setParseInputOpen(true)}>
+              <AutoFixHigh />
+            </IconButton>
+          </Tooltip>
           <Tooltip title="See Full Preview">
             <IconButton onClick={handleClickFullPreview}>
               <Visibility />
@@ -459,6 +493,24 @@ const Objective: React.FC<Props> = ({
           handleClose={() => setFullPreviewModalOpen(false)}
           disableFooter
         />
+      </Sidebar>
+      <Sidebar
+        title="Parse Options"
+        width="40%"
+        open={parseInputOpen}
+        handleClose={() => setParseInputOpen(false)}
+      >
+        <form onSubmit={handleParseOptions}>
+          <InputField
+            id="raw-input"
+            label="Raw Input Value"
+            value={rawInputToBeParsed}
+            onChange={(e) => setRawInputToBeParsed(e.target.value)}
+            type="text"
+            multiline
+          />
+          <Button>Submit</Button>
+        </form>
       </Sidebar>
       {/* Just for preview */}
       {/* <div dangerouslySetInnerHTML={{ __html: previewHTML }}></div> */}

--- a/src/pages/Questions/utils.ts
+++ b/src/pages/Questions/utils.ts
@@ -17,3 +17,33 @@ export function generateOptions(
 
   return options;
 }
+
+/**
+ * Extracts the values after (a), (b), (c), and (d) in a string, along with the preceding text.
+ *
+ * @param {string} string - The input string.
+ * @returns {Object} An object with the preceding text, the values after (a), (b), (c), and (d) as properties. The keys are the letters after the parentheses, and the values are the corresponding values.
+ * @example
+ * extractValues("The half life of a radioactive sample is 1600 years. After 800 years, if the number of radioactive nuclei changes by factor f then: (a) This is  some text (b) Something  more text (c) f = loge 2  even more text (d) Nice");
+ * // returns { precedingText: "The half life of a radioactive sample is 1600 years. After 800 years, if the number of radioactive nuclei changes by factor f then: ", a: "This is", b: "Something", c: "f = loge 2", d: "Nice" }
+ */
+export function extractOptions(string: string): {
+  precedingText: string;
+  [key: string]: string;
+} {
+  const pattern = /(.*?)\(([a-z])\) (.*?)(?=\(([a-z])\)|$)/g;
+  const values: { precedingText: string; [key: string]: string } = {
+    precedingText: "",
+  };
+
+  let match;
+  while ((match = pattern.exec(string))) {
+    const precedingText = match[1];
+    const letter = match[2];
+    const value = match[3]?.trim();
+    values[letter] = value;
+    values.precedingText += precedingText;
+  }
+
+  return values;
+}


### PR DESCRIPTION
## Parse, extract, and separate options and questions from the given raw input
- Works only for preceding text (Expect options to be at the very bottom of the question)
- Options must follow the format
```js
   (a) Val1 (b) Val2 (c) Val3 (d) Val4
```
![image](https://user-images.githubusercontent.com/55744578/208228127-29ebb416-7458-4eed-80b2-fb993e611197.png)
